### PR TITLE
🔒 Fix potential code injection via WebView in LoginScreen

### DIFF
--- a/app/src/main/kotlin/com/noxwizard/resonix/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/com/noxwizard/resonix/ui/screens/LoginScreen.kt
@@ -2,7 +2,6 @@ package com.noxwizard.resonix.ui.screens
 
 import android.annotation.SuppressLint
 import android.webkit.CookieManager
-import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
@@ -62,8 +61,17 @@ fun LoginScreen(
             WebView(context).apply {
                 webViewClient = object : WebViewClient() {
                     override fun onPageFinished(view: WebView, url: String?) {
-                        loadUrl("javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)")
-                        loadUrl("javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)")
+                        view.evaluateJavascript("window.yt.config_.VISITOR_DATA") { result ->
+                            if (result != null && result != "null") {
+                                // Result is a JSON string, so remove quotes if present
+                                visitorData = result.trim('"')
+                            }
+                        }
+                        view.evaluateJavascript("window.yt.config_.DATASYNC_ID") { result ->
+                            if (result != null && result != "null") {
+                                dataSyncId = result.trim('"').substringBefore("||")
+                            }
+                        }
 
                         if (url?.startsWith("https://music.youtube.com") == true) {
                             innerTubeCookie = CookieManager.getInstance().getCookie(url)
@@ -85,20 +93,6 @@ fun LoginScreen(
                     builtInZoomControls = true
                     displayZoomControls = false
                 }
-                addJavascriptInterface(object {
-                    @JavascriptInterface
-                    fun onRetrieveVisitorData(newVisitorData: String?) {
-                        if (newVisitorData != null) {
-                            visitorData = newVisitorData
-                        }
-                    }
-                    @JavascriptInterface
-                    fun onRetrieveDataSyncId(newDataSyncId: String?) {
-                        if (newDataSyncId != null) {
-                            dataSyncId = newDataSyncId.substringBefore("||")
-                        }
-                    }
-                }, "Android")
                 webView = this
                 loadUrl("https://accounts.google.com/ServiceLogin?continue=https%3A%2F%2Fmusic.youtube.com")
             }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed a potential Code Injection via WebView by replacing `loadUrl("javascript:...")` and `addJavascriptInterface("Android")` with `view.evaluateJavascript()` inside `LoginScreen.kt`.

⚠️ **Risk:** The potential impact if left unfixed
By using `addJavascriptInterface` and injecting Javascript via `loadUrl`, an attacker who manages to spoof the login page or if the underlying service was compromised could potentially execute arbitrary Javascript that interacts with the `Android` object exposed to the WebView context. Although the exposed functions here were relatively benign (setting shared preferences), it is a dangerous pattern that increases the attack surface of the application.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the `loadUrl` script execution and the `@JavascriptInterface` object with safer `view.evaluateJavascript()` calls that use callbacks. The evaluated results are safely handled as strings within the Kotlin callback, removing the need to expose a Java object to the Javascript context.

---
*PR created automatically by Jules for task [5423780635493041471](https://jules.google.com/task/5423780635493041471) started by @Nox-Wizard-py*