### PR TITLE
⚡ perf: offload ImageLoader.execute to IO dispatcher in ArtistScreen

### DIFF
--- a/app/src/main/kotlin/com/noxwizard/resonix/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/noxwizard/resonix/ui/screens/artist/ArtistScreen.kt
@@ -183,7 +183,9 @@ fun ArtistScreen(
                 .build()
 
             val result = runCatching {
-                context.imageLoader.execute(request)
+                withContext(Dispatchers.IO) {
+                    context.imageLoader.execute(request)
+                }
             }.getOrNull()
 
             if (result != null) {


### PR DESCRIPTION
💡 **What:** Wrapped `context.imageLoader.execute(request)` in `withContext(Dispatchers.IO)` within `ArtistScreen.kt`.

🎯 **Why:** `imageLoader.execute` is a synchronous blocking call that retrieves an image. When executed directly within a `LaunchedEffect`, it risks blocking the caller's dispatcher (often the Main thread in Compose), which can lead to UI jank and unresponsiveness. Offloading it to the IO dispatcher ensures the UI thread remains free.

📊 **Measured Improvement:** Direct performance metrics for this specific jank scenario vary heavily by device and network conditions. However, offloading blocking I/O calls off the main thread is a universally established best practice in Android/Compose. By freeing the Main dispatcher from this blocking network/disk operation, the system avoids dropping frames during the critical UI rendering window when an artist screen is first opened and its background mesh gradient is being calculated.

---
*PR created automatically by Jules for task [17557972420088358956](https://jules.google.com/task/17557972420088358956) started by @Nox-Wizard-py*