### PR TITLE
⚡ Optimize Image Loading Performance in AlbumScreen

### DIFF
--- a/app/src/main/kotlin/com/noxwizard/resonix/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/noxwizard/resonix/ui/screens/AlbumScreen.kt
@@ -167,7 +167,9 @@ fun AlbumScreen(
                 .build()
 
             val result = runCatching {
-                context.imageLoader.execute(request)
+                withContext(Dispatchers.IO) {
+                    context.imageLoader.execute(request)
+                }
             }.getOrNull()
 
             if (result != null) {


### PR DESCRIPTION
💡 **What:** Wrapped the blocking `context.imageLoader.execute(request)` call in `withContext(Dispatchers.IO)` in `AlbumScreen.kt`.
🎯 **Why:** The previous code was running the synchronous `execute` method directly inside a `LaunchedEffect`, which executes on the main thread (or the current dispatcher). This blocking operation could cause UI jank and freeze the main thread. By moving the execution to the IO dispatcher, we prevent main thread blocking, ensuring smooth UI performance during image loading. This pattern is already correctly used in `LibraryPlaylistsScreen.kt`.
📊 **Measured Improvement:** We cannot run micro-benchmarks easily in this environment, but moving a synchronous network/disk I/O operation (like image loading) off the main thread is a universally recognized and essential optimization for Android applications to maintain UI responsiveness and avoid "Application Not Responding" (ANR) errors. The performance improvement here is qualitative: a smoother UI and elimination of main thread blocking.

---
*PR created automatically by Jules for task [9522200327414198127](https://jules.google.com/task/9522200327414198127) started by @Nox-Wizard-py*