### PR TITLE
⚡ Optimize ImageLoader call in CachePlaylistScreen

### DIFF
--- a/app/src/main/kotlin/com/noxwizard/resonix/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/noxwizard/resonix/ui/screens/playlist/CachePlaylistScreen.kt
@@ -196,7 +196,7 @@ fun CachePlaylistScreen(
                 .build()
 
             val result = runCatching {
-                context.imageLoader.execute(request)
+                withContext(Dispatchers.IO) { context.imageLoader.execute(request) }
             }.getOrNull()
 
             if (result != null) {


### PR DESCRIPTION
💡 **What:** Wrapped `context.imageLoader.execute(request)` in `withContext(Dispatchers.IO)` in `CachePlaylistScreen.kt`.
🎯 **Why:** `imageLoader.execute` is a blocking call. Because it was being called without explicitly switching contexts to `Dispatchers.IO`, it could block the coroutine's current dispatcher (which may be the main/UI thread), leading to jank or freezing when loading large images.
📊 **Measured Improvement:** It's difficult to quantify the specific millisecond improvement of this optimization directly without instrumenting the UI frame rendering or running complex macrobenchmark tests. However, this is a known Kotlin Coroutine / Compose best practice because any blocking synchronous I/O on the main thread intrinsically increases frame rendering times and can cause dropped frames, so ensuring that we offload I/O tasks to `Dispatchers.IO` guarantees that the UI thread remains responsive while images load.

---
*PR created automatically by Jules for task [9781843193499289792](https://jules.google.com/task/9781843193499289792) started by @Nox-Wizard-py*