### PR TITLE
⚡ perf: move blocking imageLoader call to IO dispatcher in LocalPlaylistScreen

### DIFF
--- a/app/src/main/kotlin/com/noxwizard/resonix/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/noxwizard/resonix/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -461,7 +461,9 @@ fun LocalPlaylistScreen(
                 .build()
 
             val result = runCatching {
-                context.imageLoader.execute(request)
+                withContext(Dispatchers.IO) {
+                    context.imageLoader.execute(request)
+                }
             }.getOrNull()
 
             if (result != null) {


### PR DESCRIPTION
💡 **What:**
Wrapped `context.imageLoader.execute(request)` in `withContext(Dispatchers.IO)` within `LocalPlaylistScreen.kt`.

🎯 **Why:**
The `imageLoader.execute` method is a blocking call. Because it was being called without switching to the IO dispatcher (as done correctly elsewhere, e.g., in `LibraryPlaylistsScreen.kt`), it could potentially block the main thread or the current dispatcher running the `LaunchedEffect`. This can lead to UI jank or freezing when calculating playlist gradient colors.

📊 **Measured Improvement:**
No explicit benchmark was provided or built for this change because the nature of the issue (blocking I/O inside a coroutine without context switching) is statically identifiable and its performance impact on the UI thread (jank/stutters) is inherently resolved by shifting the execution to an IO background thread. This strictly conforms to best practices for handling blocking operations within Kotlin Coroutines in Android.

---
*PR created automatically by Jules for task [8201785444579316219](https://jules.google.com/task/8201785444579316219) started by @Nox-Wizard-py*