### PR TITLE
⚡ shift ComposeToImage coil execution to IO dispatcher

### DIFF
--- a/app/src/main/kotlin/com/noxwizard/resonix/utils/ComposeToImage.kt
+++ b/app/src/main/kotlin/com/noxwizard/resonix/utils/ComposeToImage.kt
@@ -70,7 +70,7 @@ object ComposeToImage {
                     .size(256)
                     .allowHardware(false)
                     .build()
-                val result = imageLoader.execute(request)
+                val result = withContext(Dispatchers.IO) { imageLoader.execute(request) }
                 coverArtBitmap = result.image?.toBitmap()
             } catch (_: Exception) {}
         }


### PR DESCRIPTION
💡 **What:** Wrapped `imageLoader.execute(request)` in `withContext(Dispatchers.IO)`.
🎯 **Why:** `imageLoader.execute(request)` executes I/O operations (fetching the image from cache or network). Because it was called directly inside a `withContext(Dispatchers.Default)` block without explicitly shifting dispatchers, it had the potential to block or occupy CPU-bound threads. By explicitly wrapping it in `Dispatchers.IO`, we free up default threads for other rendering and computation tasks, preventing UI jank.
📊 **Measured Improvement:** While it's impractical to set up a robust benchmark in this isolated test environment that accurately represents thread starvation on an Android device, standard Kotlin Coroutines best practices dictate that blocking I/O must always be delegated to `Dispatchers.IO`. This change reliably frees CPU-bound threads (e.g. `Dispatchers.Default` and Main) from waiting on disk/network operations, offering a clear theoretical optimization.

---
*PR created automatically by Jules for task [7684030212647557933](https://jules.google.com/task/7684030212647557933) started by @Nox-Wizard-py*