### PR TITLE
Fix Listen Together playback sync timing

### DIFF
--- a/app/src/main/kotlin/com/noxwizard/resonix/viewmodels/ListenTogetherViewModel.kt
+++ b/app/src/main/kotlin/com/noxwizard/resonix/viewmodels/ListenTogetherViewModel.kt
@@ -55,6 +55,7 @@ class ListenTogetherViewModel @Inject constructor(
 
     private val roomState = ListenTogetherManager.roomState
     private var playerConnection: PlayerConnection? = null
+    private var pendingPlayJob: kotlinx.coroutines.Job? = null
 
     @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
     private val playerListener = object : androidx.media3.common.Player.Listener {
@@ -227,21 +228,40 @@ class ListenTogetherViewModel @Inject constructor(
         val timingOffset = SocketListenTogetherRepository.roomState.value?.timingOffsetMs?.toLong() ?: 0L
         
         isApplyingRemoteEvent = true
-         when (event) {
+        pendingPlayJob?.cancel()
+        pendingPlayJob = null
+
+        when (event) {
             is PlaybackEvent.Play -> {
-                // To play a specific track if we aren't on it (basic implementation)
                 if (pc.player.currentMediaItem?.mediaId != event.trackId && event.trackId.isNotEmpty()) {
                     // Real app should lookup song and play, but for now we just play what we have
                 }
-                pc.player.seekTo(event.positionMs + timingOffset)
-                pc.player.play()
+                val waitMs = com.noxwizard.resonix.playback.PlaybackSyncCoordinator.estimatedWaitMs(event.serverTimeToExecute)
+                val seekPosition = if (waitMs < 0) {
+                    event.positionMs - waitMs // -waitMs is positive, so it advances the position
+                } else {
+                    event.positionMs
+                }
+
+                pc.player.seekTo(seekPosition + timingOffset)
+
+                if (waitMs > 0) {
+                    pendingPlayJob = viewModelScope.launch {
+                        kotlinx.coroutines.delay(waitMs)
+                        pc.player.play()
+                    }
+                } else {
+                    pc.player.play()
+                }
             }
             is PlaybackEvent.Pause -> {
                 pc.player.pause()
-                pc.player.seekTo(event.positionMs + timingOffset)
+                val correctedPosition = com.noxwizard.resonix.playback.PlaybackSyncCoordinator.correctedPosition(event.positionMs, event.serverTimeToExecute)
+                pc.player.seekTo(correctedPosition + timingOffset)
             }
             is PlaybackEvent.Seek -> {
-                pc.player.seekTo(event.positionMs + timingOffset)
+                val correctedPosition = com.noxwizard.resonix.playback.PlaybackSyncCoordinator.correctedPosition(event.positionMs, event.timestamp)
+                pc.player.seekTo(correctedPosition + timingOffset)
             }
             is PlaybackEvent.TrackChange -> {
                 // TrackChange is handled in PlayerConnection

--- a/backend/src/sync/syncHandler.js
+++ b/backend/src/sync/syncHandler.js
@@ -553,6 +553,23 @@ function handleMessage(clientId, raw, ws) {
             break;
         }
 
+        case 'ntp_probe': {
+            const { t0 } = msg;
+            if (t0 === undefined) return;
+
+            const t1 = Date.now();
+
+            if (ws.readyState === 1) {
+                ws.send(JSON.stringify({
+                    type: "ntp_response",
+                    t0: t0,
+                    t1: t1,
+                    t2: Date.now()
+                }));
+            }
+            break;
+        }
+
         case 'set_playback_permission': {
             const room = findRoomBySocket(ws);
             if (!room) return;


### PR DESCRIPTION
Fix the "Listen Together" playback synchronization issue where devices would play out-of-sync. 

This addresses two root causes:
1. The WebSocket backend lacked the `ntp_probe` handler, rendering the `PlaybackSyncCoordinator`'s NTP offset calculation moot.
2. The Android client's `ListenTogetherViewModel` bypassed the NTP-corrected `estimatedWaitMs` and `correctedPosition` helpers when applying `PlaybackEvent.Play`, `Pause`, and `Seek`, causing local and remote clients to fall out of step.

---
*PR created automatically by Jules for task [12359831758452670059](https://jules.google.com/task/12359831758452670059) started by @Nox-Wizard-py*